### PR TITLE
Add md tips to new responses and edit responses

### DIFF
--- a/src/app/phase-bug-reporting/new-issue/new-issue.component.html
+++ b/src/app/phase-bug-reporting/new-issue/new-issue.component.html
@@ -22,17 +22,20 @@
           >
           </app-comment-editor>
         </div>
-
-        <button
-          style="float: right"
-          class="submit-new-bug-report"
-          type="submit"
-          mat-stroked-button
-          color="primary"
-          [disabled]="!newIssueForm.valid || isFormPending"
-        >
-          {{ this.submitButtonText }}
-        </button>
+        <div style="display: flex; justify-content: end; margin-bottom: 10px">
+          <button
+            class="submit-new-bug-report"
+            type="submit"
+            mat-stroked-button
+            color="primary"
+            [disabled]="!newIssueForm.valid || isFormPending"
+          >
+            {{ this.submitButtonText }}
+          </button>
+        </div>
+        <div>
+          <app-md-tips></app-md-tips>
+        </div>
       </div>
 
       <div class="column right">

--- a/src/app/phase-bug-reporting/phase-bug-reporting.module.ts
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.module.ts
@@ -10,6 +10,7 @@ import { IssueComponent } from './issue/issue.component';
 import { NewIssueComponent } from './new-issue/new-issue.component';
 import { PhaseBugReportingRoutingModule } from './phase-bug-reporting-routing.module';
 import { PhaseBugReportingComponent } from './phase-bug-reporting.component';
+import { MdTipsModule } from '../shared/md-tips/md-tips.module';
 
 @NgModule({
   imports: [
@@ -20,7 +21,8 @@ import { PhaseBugReportingComponent } from './phase-bug-reporting.component';
     ViewIssueModule,
     MarkdownModule.forChild(),
     IssueTablesModule,
-    LabelDropdownModule
+    LabelDropdownModule,
+    MdTipsModule
   ],
   declarations: [PhaseBugReportingComponent, NewIssueComponent, IssueComponent]
 })

--- a/src/app/shared/md-tips/md-tips.component.css
+++ b/src/app/shared/md-tips/md-tips.component.css
@@ -1,0 +1,7 @@
+.container {
+  background-color: #f5f5f5;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  font-size: 12px;
+  color: gray;
+}

--- a/src/app/shared/md-tips/md-tips.component.html
+++ b/src/app/shared/md-tips/md-tips.component.html
@@ -1,0 +1,16 @@
+<div class="container">
+  <ul>
+    <li>
+      <p>
+        <code>`` ``</code> : To escape backticks in markdown. For example, to display a backtick like <code>`code`</code> in a code block,
+        use <code>`` ``</code>.
+      </p>
+    </li>
+    <li>
+      <p>
+        \ : To escape special characters &#96;&#42;&#95;&#123;&#125;&#91;&#93;&#44;&#46;&#40;&#41;&#35;&#43;&#45;&#46;&#33;&#124; in
+        markdown. For example, to display an asterisk like *asterisk*, use <code>\*asterisk\*</code>.
+      </p>
+    </li>
+  </ul>
+</div>

--- a/src/app/shared/md-tips/md-tips.component.spec.ts
+++ b/src/app/shared/md-tips/md-tips.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MdTipsComponent } from './md-tips.component';
+
+describe('MdTipsComponent', () => {
+  let component: MdTipsComponent;
+  let fixture: ComponentFixture<MdTipsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MdTipsComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MdTipsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/md-tips/md-tips.component.ts
+++ b/src/app/shared/md-tips/md-tips.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-md-tips',
+  templateUrl: './md-tips.component.html',
+  styleUrls: ['./md-tips.component.css']
+})
+export class MdTipsComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/shared/md-tips/md-tips.module.ts
+++ b/src/app/shared/md-tips/md-tips.module.ts
@@ -1,0 +1,11 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { SharedModule } from '../shared.module';
+import { MdTipsComponent } from './md-tips.component';
+
+@NgModule({
+  declarations: [MdTipsComponent],
+  imports: [CommonModule, SharedModule],
+  exports: [MdTipsComponent]
+})
+export class MdTipsModule {}

--- a/src/app/shared/view-issue/view-issue.component.html
+++ b/src/app/shared/view-issue/view-issue.component.html
@@ -65,6 +65,11 @@
         (updateEditState)="updateTutorResponseEditState($event)"
       >
       </app-issue-dispute>
+
+      <!-- Md Tips While Editing -->
+      <div *ngIf="this.isEditing() || this.isResponseEditing()">
+        <app-md-tips></app-md-tips>
+      </div>
     </div>
 
     <div class="column right">

--- a/src/app/shared/view-issue/view-issue.component.ts
+++ b/src/app/shared/view-issue/view-issue.component.ts
@@ -86,6 +86,10 @@ export class ViewIssueComponent implements OnInit, OnDestroy, OnChanges {
     return this.isIssueDescriptionEditing || this.isTutorResponseEditing || this.isTeamResponseEditing;
   }
 
+  isResponseEditing(): boolean {
+    return this.isTeamResponseEditing || this.isTesterResponseEditing || this.isTutorResponseEditing || this.hasNoTeamResponse();
+  }
+
   updateIssue(newIssue: Issue) {
     this.issue = newIssue;
     this.issueService.updateLocalStore(newIssue);

--- a/src/app/shared/view-issue/view-issue.module.ts
+++ b/src/app/shared/view-issue/view-issue.module.ts
@@ -12,6 +12,7 @@ import { TeamAcceptedModule } from './team-accepted/team-accepted.module';
 import { TeamResponseModule } from './team-response/team-response.module';
 import { TesterResponseModule } from './tester-response/tester-response.module';
 import { ViewIssueComponent } from './view-issue.component';
+import { MdTipsModule } from '../md-tips/md-tips.module';
 
 @NgModule({
   exports: [ViewIssueComponent],
@@ -28,7 +29,8 @@ import { ViewIssueComponent } from './view-issue.component';
     IssueComponentsModule,
     LabelDropdownModule,
     MarkdownModule.forChild(),
-    TeamAcceptedModule
+    TeamAcceptedModule,
+    MdTipsModule
   ]
 })
 export class ViewIssueModule {}


### PR DESCRIPTION
### Summary:
Enhancement: Add markdown tips below the comment editor

### Changes Made:
- Displays useful markdown tips for example for escaping characters
    - New Issue
        ![image](https://github.com/user-attachments/assets/468a720e-8bb4-4635-a0bb-a1594cd0fdd2)
    - New Issue Edit
        ![image](https://github.com/user-attachments/assets/e3e594e9-cae6-43ff-a6ff-670c1a55f3de)
    - New Team Response
        ![image](https://github.com/user-attachments/assets/09f02eca-2119-4c07-99f9-b5e3ff94b547)
    - New Team Response Edit
        ![image](https://github.com/user-attachments/assets/563e020f-5e76-4000-aa03-4d6fade1747d)
    - Markdown tips will not be shown when user is not editing
        ![image](https://github.com/user-attachments/assets/2352e341-366b-4e8a-bef3-029fcaafffd2)

Proposed Commit Message:

```
Add Markdown tips for using the comment editor during PE

Students frequently need to escape special characters and format code chunks during PE but may not know how to do so. This often leads to wasted time searching for instructions or errors caused by incorrect formatting.

Add a section in the comment editor with Markdown tips to guide students on escaping special characters and quoting code chunks effectively.

This approach is intended to improve the overall user experience, reduce the likelihood of formatting errors, and save students' time during high-pressure situations like PE.
````


